### PR TITLE
Don't loop-and-grep for every string; grep once

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ Stat issue (regarding the CREATED file stamp on Linux file systems)
 
 # Known Issues
 
-The "string detection" function needs a more effective way to check files for certain strings. I already tried to concatenate the string IOC array to a long expression joined with " -e " in order to "pre-grep" the file with "grep -e string1 -e string2 -e string3 $filename" but didn't get it to work.  
-
 # Contact 
 
 via Twitter @Cyb3rOps

--- a/fenrir.sh
+++ b/fenrir.sh
@@ -133,6 +133,9 @@ function scan_dirs
             for fsm_dir in "${FORCED_STRING_MATCH_DIRS[@]}";
             do
                 # echo "Checking if $ex_dir is in $dir"
+                # The following check matches when $fsm_dir is ANYWHERE in the
+                # $file_path, not only at the beginning. As we're just doing
+                # more checks in that case, we don't care
                 if [ "${file_path/$fsm_dir}" != "$file_path" ]; then
                     DO_STRING_CHECK=1
                     if [ $DEBUG -eq 1 ]; then
@@ -312,6 +315,9 @@ function check_dir
     do
         # echo "Checking if $ex_dir is in $dir"
         if [ "${dir/$ex_dir}" != "$dir" ]; then
+            if [ "${dir/#$ex_dir}" = "$dir" ];then
+                log debug "Skipping $file_path due to WRONG exclusion bc/ $ex_dir in the middle of the path..."
+            fi
             result=1
         fi
     done

--- a/fenrir.sh
+++ b/fenrir.sh
@@ -112,8 +112,8 @@ function scan_dirs
                     if [ $DEBUG -eq 1 ]; then
                         log debug "Deactivating some checks on $file_path due to irrelevant extension ..."
                     fi
-                DO_STRING_CHECK=0
-                DO_HASH_CHECK=0
+                    DO_STRING_CHECK=0
+                    DO_HASH_CHECK=0
                 fi
             fi
 
@@ -376,7 +376,7 @@ function log {
     local message="$2"
     local ts=$(timestamp)
 
-    # Exclude certain strings (false psotives)
+    # Exclude certain strings (false positives)
     for ex_string in "${EXCLUDE_STRINGS[@]}";
     do
         # echo "Checking if $ex_string is in $message"

--- a/fenrir.sh
+++ b/fenrir.sh
@@ -402,7 +402,7 @@ function log {
     fi
     # Log to command line
     if [[ $LOG_TO_CMDLINE -eq 1 ]]; then
-        echo "$message"
+        echo "$message" >&2
     fi
 }
 


### PR DESCRIPTION
This patch uses grep's (POSIX) -F to actually grep for more than one pattern, so that we don't need to run grep for every pattern, but only once. This speeds up things considerably...
