### PR TITLE
bash2 compatible array

### DIFF
--- a/fenrir.sh
+++ b/fenrir.sh
@@ -453,13 +453,9 @@ function log {
 function pseudo_hash {
 	local hash=$1
 	#echo hash: $hash
-	pseudo_h=1
 
-	# max 32bit = 1..10
-	for lola in {1..10};
-	do
-		pseudo_h+=$((${hash:lola:1}*10**lola))
-	done
+	short_hash="0x${hash:0:8}"
+	let pseudo_h=$(($short_hash))
 
 	# use global var to save the fork of /bin/echo
 	#echo $pseudo_h


### PR DESCRIPTION
uses a pseudo hash function to speed up hash-ioc search. only useful for lots of iocs

takes 15 sec on my machine to read the signature base iocs (which could be speed up by converting them beforehand and storing them diretly in hash-iocs.txt, but then runs about twice as fast.